### PR TITLE
Fix data rounding error for brakeBias and Temperature

### DIFF
--- a/Service/Windows/visualstudio/SimDisplayCLI/SimDisplayCLI.c
+++ b/Service/Windows/visualstudio/SimDisplayCLI/SimDisplayCLI.c
@@ -337,7 +337,7 @@ int doCsv(int argc, const wchar_t *argv[])
 				snprintf(csvRecord, maxCsvRecord,
 					"%d,%d,%d,%d,%d,"
 					"%d,%d,%f,%u,%d,%f,%u,"
-					"%.7f,%u,%f,%d,%f,%f\n",
+					"%f,%u,%f,%d,%f,%f\n",
 					gra->status, phy->rpms, sta->maxRpm, phy->pitLimiterOn, phy->gear,
 					gra->TC, gra->TCCut, phy->tc, (uint8_t)phy->tc, gra->ABS, phy->abs, (uint8_t)phy->abs,
 					phy->brakeBias, bbFromBrakeBias(phy->brakeBias, lookupBBOffset(sta->carModel)), gra->fuelEstimatedLaps, gra->EngineMap, phy->airTemp, phy->roadTemp),

--- a/Service/Windows/visualstudio/SimDisplayCLI/SimDisplayCLI.c
+++ b/Service/Windows/visualstudio/SimDisplayCLI/SimDisplayCLI.c
@@ -209,8 +209,8 @@ int doSend(int argc, const wchar_t *argv[])
 		packet.bb = bbFromBrakeBias(phy->brakeBias, bbOffset);
 		packet.remlaps = (uint8_t)gra->fuelEstimatedLaps; // Only full laps are useful to the driver.
 		packet.map = gra->EngineMap + 1;
-		packet.airt = (uint8_t)(phy->airTemp+0.5f);
-		packet.roadt = (uint8_t)(phy->roadTemp+0.5f);
+		packet.airt = (uint8_t)phy->airTemp; // match ACC's UI: floor instead of round.
+		packet.roadt = (uint8_t)phy->roadTemp; // match ACC's UI: floor instead of round.
 
 		DWORD bytesWritten;
 		WriteFile(comPort, &packet, sizeof(packet), &bytesWritten, NULL);

--- a/Service/Windows/visualstudio/SimDisplayCLI/SimDisplayCLI.c
+++ b/Service/Windows/visualstudio/SimDisplayCLI/SimDisplayCLI.c
@@ -130,7 +130,7 @@ float lookupBBOffset(wchar_t *carModel)
 	return 0.0f;
 }
 
-uint16_t brakeBiasToBB(float brakeBias, float offset)
+uint16_t bbFromBrakeBias(float brakeBias, float offset)
 {
 	return brakeBias ? (uint16_t)(brakeBias * 1000.0f + offset + 0.5f) : 0;
 }
@@ -206,7 +206,7 @@ int doSend(int argc, const wchar_t *argv[])
 		packet.tcaction = (uint8_t)phy->tc;
 		packet.abs = gra->ABS;
 		packet.absaction = (uint8_t)phy->abs;
-		packet.bb = brakeBiasToBB(phy->brakeBias, bbOffset);
+		packet.bb = bbFromBrakeBias(phy->brakeBias, bbOffset);
 		packet.remlaps = (uint8_t)gra->fuelEstimatedLaps; // Only full laps are useful to the driver.
 		packet.map = gra->EngineMap + 1;
 		packet.airt = (uint8_t)(phy->airTemp+0.5f);


### PR DESCRIPTION
Factored out the formula into bbFromBrakeBias() so that both CSV and SEND do "the right thing", showing the same number as in the UI.
TODO: apply same concept to air and road temperatures.